### PR TITLE
Escape HTML in format args

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The following options can be passed to the transform:
 
 `source` specifies the directory in which the `<LOCALE>.po` files are stored. It defaults to `./locales`
 
+##### `allowHtml`
+
+By default, all strings passed as arguments (e.g. `__('Happy birthday %s', 'Guillermo')`) are HTML-escaped in order to prevent XSS-style attacks. If you can make sure you never pass user created content, you can disable this behavior by passing `allowHtml: true`.
+
 ##### `global`
 
 `global` defines the global function identifier that is used for defining strings in code. It defaults to `__`.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "arg": "^4.1.3",
+    "escape-html": "^1.0.3",
     "jscodeshift": "^0.10.0",
     "pofile": "^1.1.0",
     "through2": "^4.0.2"

--- a/test/html.js
+++ b/test/html.js
@@ -1,0 +1,2 @@
+/* global __ */
+console.log(__('Hello %s!', '<i>world</i>'))

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,40 @@ tape.test('returns the default language when no options are passed', function (t
   })
 })
 
+tape.test('escapes HTML in format arguments', function (t) {
+  bundle('html.js', null, function (err, src) {
+    if (err) {
+      t.fail(err)
+    }
+
+    vm.runInNewContext(src, {
+      console: { log: log }
+    })
+
+    function log (value) {
+      t.equal(value, 'Hello &lt;i&gt;world&lt;/i&gt;!', 'passes')
+      t.end()
+    }
+  })
+})
+
+tape.test('does not escape HTML in format arguments if explicitly allowed', function (t) {
+  bundle('html.js', { allowHtml: true }, function (err, src) {
+    if (err) {
+      t.fail(err)
+    }
+
+    vm.runInNewContext(src, {
+      console: { log: log }
+    })
+
+    function log (value) {
+      t.equal(value, 'Hello <i>world</i>!', 'passes')
+      t.end()
+    }
+  })
+})
+
 tape.test('returns the given language', function (t) {
   bundle('log.js', { locale: 'de', source: './test/locales' }, function (err, src) {
     if (err) {


### PR DESCRIPTION
Format args can potentially contain user input, so leaving them unescaped creates a potential content injection vector.