### PR TITLE
Update jscodeshift so transient dependency on `colors` is removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "arg": "^4.1.3",
-    "jscodeshift": "^0.10.0",
+    "jscodeshift": "^0.13.1",
     "pofile": "^1.1.0",
     "through2": "^4.0.2"
   }


### PR DESCRIPTION
See: https://github.com/offen/offen/pull/698